### PR TITLE
Proposal to use git-master dependencies for collaboration, testing, and CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,7 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
-plotters-backend = "^0.0.*"
+[dependencies.plotters-backend]
+branch = "master"
+git = "https://github.com/plotters-rs/plotters-backend"
+# version = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.plotters-backend]
-branch = "master"
 git = "https://github.com/plotters-rs/plotters-backend"
 # version = "0.3.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,8 +106,8 @@ impl DrawingBackend for TextDrawingBackend {
         &mut self,
         mut upper_left: (i32, i32),
         mut bottom_right: (i32, i32),
-        style: &S,
-        fill: bool,
+        _style: &S,
+        _fill: bool,
     ) -> Result<(), DrawingErrorKind<Self::ErrorType>> {
         upper_left.0 = upper_left.0.max(0).min(self.size.0 as i32);
         upper_left.1 = upper_left.1.max(0).min(self.size.1 as i32);


### PR DESCRIPTION
This proposal aims to improve collaboration, testing, and CI by altering the version of the `plotters-backend` dependency in `Cargo.toml`. Instead of using the stable version of that crate, the `git-master` version is used.

Using the `git-master` version of `plotters-backend` is vital for pre-release quality assurance and frustration-free collaboration in Plotters. It also reduces surprises at release time.

This is part of the proposal discussed on plotters-rs/plotters#373