### PR TITLE
fix: :bug: cannot use with plotters from crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.plotters-backend]
-git = "https://github.com/plotters-rs/plotters"
-# version = "0.3.1"
+# git = "https://github.com/plotters-rs/plotters"
+version = "0.3.1"


### PR DESCRIPTION
I could not compile my crate when using plotters-text with plotters from crates.io because it uses plotters from git so I changed that